### PR TITLE
Introduce BOM module

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-module.gradle
@@ -1,8 +1,23 @@
 plugins {
-    id 'io.micronaut.build.internal.test-pulsar-shared-module'
+    id 'groovy'
 }
 
 dependencies {
-    implementation projects.pulsar
-    implementation mn.reactor
+    annotationProcessor mn.micronaut.inject.java
+    testImplementation mn.micronaut.inject.java
+    testImplementation mn.micronaut.inject.groovy
+    testImplementation projects.pulsar
+    testImplementation projects.testSuite.testPulsarSharedModule
+    testImplementation mn.micronaut.inject
+    testImplementation mn.micronaut.reactor
+    testImplementation libs.micronaut.grpc.protobuf.support
+}
+
+tasks.named('test') {
+    // Use JUnit Platform for unit tests.
+    useJUnitPlatform()
+}
+
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-multitenant-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-multitenant-module.gradle
@@ -1,8 +1,0 @@
-plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
-}
-
-dependencies {
-    implementation projects.pulsar
-    implementation mn.reactor
-}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-shared-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-pulsar-shared-module.gradle
@@ -1,8 +1,0 @@
-plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
-}
-
-dependencies {
-    implementation projects.pulsar
-    implementation mn.reactor
-}

--- a/doc-examples/example-groovy/build.gradle
+++ b/doc-examples/example-groovy/build.gradle
@@ -1,12 +1,6 @@
 plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
+    alias libs.plugins.micronaut.minimal.app
     id "groovy"
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
 }
 
 dependencies {
@@ -17,6 +11,6 @@ dependencies {
     testImplementation mn.spock
 }
 
-tasks.withType(GroovyCompile) {
+tasks.withType(GroovyCompile).configureEach {
     groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
 }

--- a/doc-examples/example-java/build.gradle
+++ b/doc-examples/example-java/build.gradle
@@ -1,12 +1,6 @@
 plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
+    alias libs.plugins.micronaut.minimal.app
     id "java"
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
 }
 
 dependencies {

--- a/doc-examples/example-kotlin/build.gradle
+++ b/doc-examples/example-kotlin/build.gradle
@@ -1,13 +1,7 @@
 plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
     alias libs.plugins.kotlin.jvm
     alias libs.plugins.kotlin.kapt
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
+    alias libs.plugins.micronaut.minimal.app
 }
 
 dependencies {
@@ -24,13 +18,13 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.0'
 }
 
-test {
+tasks.named('test') {
     systemProperties['junit.jupiter.execution.parallel.enabled'] = true
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     forkEvery = 1
 }
 
-compileTestKotlin {
+tasks.named('compileTestKotlin') {
     kotlinOptions {
         jvmTarget = '1.8'
         javaParameters = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ spockVersion=2.0-groovy-3.0
 kotlinVersion=1.6.20
 kotlinCoroutinesVersion=1.6.1
 micronautBuildVersion=1.1.5
-micronautGradlePluginVersion=2.0.3
 
 title=Micronaut Pulsar
 projectDesc=Integration between Micronaut and Apache Pulsar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,20 @@
 [versions]
+conscrypt-openjdk = "2.5.2"
 kotlin = '1.6.20'
 kotest = '4.6.4'
 testcontainers = '1.16.3'
 junit = '5.8.2'
-pulsar = '2.10.0'
 micronaut-serde = '1.0.1'
+micronaut-gradle = '3.4.1'
+
+managed-pulsar = '2.10.0'
 
 [libraries]
+# Managed libraries
+managed-pulsar = { module = 'org.apache.pulsar:pulsar-client', version.ref= 'managed-pulsar' }
+
+# Other libraries
+conscrypt-openjdk = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref="conscrypt-openjdk" }
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 kotest = { module = 'io.kotest:kotest-runner-junit5', version.ref = 'kotest' }
 kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' }
@@ -14,11 +22,15 @@ kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib-jdk8', version.re
 testcontainers = { module = 'org.testcontainers:testcontainers', version.ref = 'testcontainers' }
 testcontainers-spock = { module = 'org.testcontainers:spock', version.ref = 'testcontainers' }
 testcontainers-pulsar = { module = 'org.testcontainers:pulsar', version.ref = 'testcontainers' }
-pulsar = { module = 'org.apache.pulsar:pulsar-client', version.ref= 'pulsar' }
 micronaut-serde-processor = { module = "io.micronaut.serde:micronaut-serde-processor", version.ref = "micronaut-serde" }
 micronaut-serde-api = { module = "io.micronaut.serde:micronaut-serde-api", version.ref = "micronaut-serde" }
 micronaut-serde-support = { module = "io.micronaut.serde:micronaut-serde-support", version.ref = "micronaut-serde" }
 
+# This can be replaced with the Micronaut BOM version once the base Micronaut version is bumped to 3.5
+micronaut-grpc-protobuf-support = "io.micronaut.grpc:micronaut-protobuff-support:3.1.3"
+
 [plugins]
 kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
 kotlin-kapt = { id = 'org.jetbrains.kotlin.kapt', version.ref = 'kotlin' }
+micronaut-minimal-app = { id = 'io.micronaut.minimal.application', version.ref = 'micronaut-gradle' }
+micronaut-minimal-library = { id = 'io.micronaut.minimal.library', version.ref = 'micronaut-gradle' }

--- a/pulsar-bom/build.gradle
+++ b/pulsar-bom/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "io.micronaut.build.internal.bom"
+}

--- a/pulsar-multitenant/build.gradle
+++ b/pulsar-multitenant/build.gradle
@@ -11,12 +11,12 @@ micronautBuild {
 dependencies {
     api mn.micronaut.inject
     api mn.micronaut.messaging
-    api libs.pulsar
+    api libs.managed.pulsar
 
     implementation projects.pulsar
     implementation mn.micronaut.multitenancy
     compileOnly "jakarta.inject:jakarta.inject-api"
-    compileOnly 'io.micronaut.reactor:micronaut-reactor'
+    compileOnly mn.micronaut.reactor
 }
 
 repositories {

--- a/pulsar/build.gradle
+++ b/pulsar/build.gradle
@@ -14,23 +14,13 @@ dependencies {
 
     api mn.micronaut.inject
     api mn.micronaut.messaging
-    api libs.pulsar
+    api libs.managed.pulsar
 
     compileOnly "jakarta.inject:jakarta.inject-api"
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     compileOnly 'com.google.protobuf:protobuf-java:3.20.1'
-    compileOnly 'io.micronaut.reactor:micronaut-reactor'
-    compileOnly 'io.micronaut.grpc:micronaut-protobuff-support:3.1.3'
-}
-
-test {
-    jvmArgs '-Duser.country=US'
-    jvmArgs '-Duser.language=en'
-    testLogging {
-        showStandardStreams = true
-        exceptionFormat = 'full'
-    }
-    failFast = true
+    compileOnly mn.micronaut.reactor
+    compileOnly libs.micronaut.grpc.protobuf.support
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,9 +22,10 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = 'pulsar-root'
+rootProject.name = 'pulsar-parent'
 
 include 'pulsar'
+include 'pulsar-bom'
 include 'pulsar-multitenant'
 include 'test-suite:test-pulsar-shared-module'
 include 'test-suite:test-pulsar-module'
@@ -32,4 +33,3 @@ include 'test-suite:test-pulsar-multitenant-module'
 include 'doc-examples:example-java'
 include 'doc-examples:example-kotlin'
 include 'doc-examples:example-groovy'
-

--- a/test-suite/test-pulsar-module/build.gradle
+++ b/test-suite/test-pulsar-module/build.gradle
@@ -1,20 +1,3 @@
 plugins {
-    id 'io.micronaut.build.internal.pulsar-module'
-    id "java"
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
-}
-
-dependencies {
-    implementation project(':pulsar')
-    annotationProcessor mn.micronaut.inject.java
-    annotationProcessor mn.micronaut.inject.groovy
-    testImplementation mn.micronaut.inject
-    testImplementation project(':test-suite:test-pulsar-shared-module')
-    testImplementation 'io.micronaut.reactor:micronaut-reactor'
-    testImplementation 'io.micronaut.grpc:micronaut-protobuff-support:3.1.3'
+    id 'io.micronaut.build.internal.test-pulsar-module'
 }

--- a/test-suite/test-pulsar-multitenant-module/build.gradle
+++ b/test-suite/test-pulsar-multitenant-module/build.gradle
@@ -1,28 +1,9 @@
 plugins {
-    id 'io.micronaut.build.internal.pulsar-multitenant-module'
-    id "java"
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
+    id 'io.micronaut.build.internal.test-pulsar-module'
 }
 
 dependencies {
-    implementation project(':pulsar-multitenant')
-    testCompileOnly mn.micronaut.inject.java
-    testImplementation mn.micronaut.inject.java
-
-    testImplementation project(':test-suite:test-pulsar-shared-module')
-    testImplementation mn.micronaut.inject
-    testImplementation mn.spock
-    testImplementation mn.reactor
-    testImplementation mn.micronaut.test.spock
+    testImplementation projects.pulsarMultitenant
     testImplementation mn.micronaut.multitenancy
     testImplementation mn.micronaut.http.client
-}
-
-tasks.withType(GroovyCompile) {
-    groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
 }

--- a/test-suite/test-pulsar-shared-module/build.gradle
+++ b/test-suite/test-pulsar-shared-module/build.gradle
@@ -1,27 +1,25 @@
 plugins {
-    id 'io.micronaut.build.internal.test-pulsar-shared-module'
-}
-
-micronautBuild {
-    binaryCompatibility {
-        enabled = false
-    }
+    id 'java-library'
+    id 'groovy'
 }
 
 dependencies {
+    api platform(mn.micronaut.bom)
+    api project(':pulsar')
+    api mn.spock
+    api mn.groovy
+
     implementation mn.micronaut.inject
     implementation mn.micronaut.inject.groovy
     implementation mn.micronaut.inject.java
-    implementation project(':pulsar')
 
-    runtimeOnly 'io.micronaut:micronaut-http-server-netty'
-    runtimeOnly 'io.micronaut:micronaut-runtime'
-    implementation 'io.micronaut.reactor:micronaut-reactor'
+    runtimeOnly mn.micronaut.http.server.netty
+    runtimeOnly mn.micronaut.runtime
+    implementation mn.micronaut.reactor
     implementation mn.micronaut.test.spock
-    implementation mn.spock
     implementation libs.testcontainers.spock
     implementation libs.testcontainers.pulsar
-    implementation 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
-    implementation 'io.micronaut.grpc:micronaut-protobuff-support:3.1.3'
+    implementation libs.conscrypt.openjdk
+    implementation libs.micronaut.grpc.protobuf.support
 
 }


### PR DESCRIPTION
While investigating support for Pulsar in Micronaut Test Resources,
we figured out that the Pulsar module isn't included in the Micronaut BOM.

Prior to adding it to the Micronaut BOM, it would be nice to align this
module with the other Micronaut modules so that it publishes a BOM.

This is what this commit does: it adds a `pulsar-bom` module. As part
of the process, I cleaned up the build, which was setup in a weird way,
with test modules applying modules which are normally only for published
modules.
This also imples renaming the root project to the convention recognized
by the BOM plugin.