### PR TITLE
fix dependency notation in docs

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,6 +1,6 @@
 To configure the Apache Pulsar client, first add the `micronaut-pulsar` module dependency:
 
-dependency::micronaut-pulsar[groupId="io.micronaut.pulsar"]
+dependency:micronaut-pulsar[groupId="io.micronaut.pulsar"]
 
 Then configure the URI of the Pulsar cluster or standalone server to communicate with:
 


### PR DESCRIPTION
syntax error resulted in incorrect dependency notation in generated docs