### PR TITLE
cleanup, test switch form hostname skip verify to allow insecure

### DIFF
--- a/test-suite/test-pulsar-module/src/test/groovy/io/micronaut/pulsar/TlsAwareClientTest.groovy
+++ b/test-suite/test-pulsar-module/src/test/groovy/io/micronaut/pulsar/TlsAwareClientTest.groovy
@@ -49,7 +49,7 @@ class TlsAwareClientTest extends Specification {
         String tlsPathForPulsar = new File(tlsPath).absolutePath
         this.context = ApplicationContext.run(
                 ['pulsar.service-url'                  : PulsarTls.pulsarBrokerTlsUrl,
-                 'pulsar.tls-trust-certs-file-path'    : tlsPathForPulsar,
+                 'pulsar.tls-cert-file-path'           : tlsPathForPulsar,
                  'pulsar.shutdown-on-subscriber-error' : true,
                  // 'pulsar.tls-verify-hostname': false can't work anymore
                  // as pulsar doesn't set it on trust store that it builds

--- a/test-suite/test-pulsar-module/src/test/groovy/io/micronaut/pulsar/TlsAwareClientTest.groovy
+++ b/test-suite/test-pulsar-module/src/test/groovy/io/micronaut/pulsar/TlsAwareClientTest.groovy
@@ -1,4 +1,7 @@
 package io.micronaut.pulsar
+
+import io.micronaut.context.ApplicationContext
+
 /*
  * Copyright 2017-2022 original authors
  *
@@ -15,8 +18,6 @@ package io.micronaut.pulsar
  * limitations under the License.
  */
 
-
-import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import io.micronaut.pulsar.annotation.PulsarConsumer
@@ -24,14 +25,9 @@ import io.micronaut.pulsar.annotation.PulsarProducer
 import io.micronaut.pulsar.annotation.PulsarProducerClient
 import io.micronaut.pulsar.annotation.PulsarSubscription
 import io.micronaut.pulsar.shared.PulsarTls
-import org.apache.pulsar.client.api.Consumer
-import org.apache.pulsar.client.api.Message
-import org.apache.pulsar.client.api.MessageId
-import org.apache.pulsar.client.api.PulsarClient
-import org.apache.pulsar.client.api.Reader
+import org.apache.pulsar.client.api.*
 import org.apache.pulsar.client.impl.schema.StringSchema
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Stepwise
@@ -41,7 +37,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReadWriteLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
-@Ignore
 @Stepwise
 class TlsAwareClientTest extends Specification {
 
@@ -53,13 +48,13 @@ class TlsAwareClientTest extends Specification {
         String tlsPath = ClassLoader.getSystemClassLoader().getResource('ca.cert.pem').path
         String tlsPathForPulsar = new File(tlsPath).absolutePath
         this.context = ApplicationContext.run(
-                ['pulsar.service-url'                 : PulsarTls.pulsarBrokerTlsUrl,
-                 'pulsar.tls-cert-file-path'          : tlsPathForPulsar,
-                 'pulsar.shutdown-on-subscriber-error': true,
-                 'pulsar.tls-ciphers'                 : ['TLS_AES_256_GCM_SHA384'],
-                 'pulsar.tls-protocols'               : ['TLSv1.3'],
-                 'pulsar.tls-verify-hostname'         : false,
-                 'spec.name'                          : getClass().simpleName],
+                ['pulsar.service-url'                  : PulsarTls.pulsarBrokerTlsUrl,
+                 'pulsar.tls-trust-certs-file-path'    : tlsPathForPulsar,
+                 'pulsar.shutdown-on-subscriber-error' : true,
+                 // 'pulsar.tls-verify-hostname': false can't work anymore
+                 // as pulsar doesn't set it on trust store that it builds
+                 'pulsar.tls-allow-insecure-connection': true,
+                 'spec.name'                           : getClass().simpleName],
                 Environment.TEST
         )
     }

--- a/test-suite/test-pulsar-shared-module/src/main/groovy/io/micronaut/pulsar/shared/PulsarTls.groovy
+++ b/test-suite/test-pulsar-shared-module/src/main/groovy/io/micronaut/pulsar/shared/PulsarTls.groovy
@@ -16,50 +16,40 @@
 package io.micronaut.pulsar.shared
 
 
-import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.Container
 import org.testcontainers.containers.PulsarContainer
 import org.testcontainers.containers.output.OutputFrame
 import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
 
 abstract class PulsarTls {
 
-    public static final String PULSAR_VERSION = "3.3.0"
+    public static final String PULSAR_VERSION = "3.3.9"
 
     public static final int HTTPS = 8443
     public static final int BROKER_SSL = 6651
     private static final PulsarContainer PULSAR_CONTAINER =
             new PulsarContainer(DockerImageName.parse("apachepulsar/pulsar:${PULSAR_VERSION}"))
-    private static ClassLoader resourceLoader
     private static final String PULSAR_CLI_ADMIN = "/pulsar/bin/pulsar-admin"
 
     static {
-        resourceLoader = ClassLoader.getSystemClassLoader()
-
-        final var brokerCert = resourceLoader.getResource("broker.cert.pem").path
-        PULSAR_CONTAINER.addFileSystemBind(new File(brokerCert).path, "/my-ca/broker.cert.pem", BindMode.READ_ONLY)
-        final var brokerKey = resourceLoader.getResource("broker.key-pk8.pem").path
-        PULSAR_CONTAINER.addFileSystemBind(new File(brokerKey).path, "/my-ca/broker.key-pk8.pem", BindMode.READ_ONLY)
-        final var caCert = resourceLoader.getResource("ca.cert.pem").path
-        PULSAR_CONTAINER.addFileSystemBind(new File(caCert).path, "/my-ca/ca.cert.pem", BindMode.READ_ONLY)
-
-        final var standaloneConfFile = new File(resourceLoader.getResource("standalone.conf").path)
-        standaloneConfFile.setWritable(true,false)
-        standaloneConfFile.setReadable(true,false)
-        standaloneConfFile.setExecutable(true,false)
-        final var standalone = standaloneConfFile.path
-        final var clientConfFile = new File(resourceLoader.getResource("client.conf").path)
-        clientConfFile.setWritable(true, false)
-        clientConfFile.setReadable(true, false)
-        clientConfFile.setExecutable(true, false)
-        final var client = clientConfFile.path
-
-        PULSAR_CONTAINER.addFileSystemBind(standalone, "/pulsar/conf/standalone.conf", BindMode.READ_WRITE)
-        PULSAR_CONTAINER.addFileSystemBind(client, "/pulsar/conf/client.conf", BindMode.READ_WRITE)
+        PULSAR_CONTAINER
+                .withCopyFileToContainer(MountableFile.forClasspathResource("ca.cert.pem", 0777), "/pulsar/certs/ca.cert.pem")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("broker.cert.pem", 0777), "/pulsar/certs/broker.cert.pem")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("broker.key-pk8.pem", 0777), "/pulsar/certs/broker.key-pk8.pem")
 
         PULSAR_CONTAINER.addExposedPorts(HTTPS, BROKER_SSL)
         try {
-            PULSAR_CONTAINER.start()
+            PULSAR_CONTAINER
+                    .withEnv("PULSAR_PREFIX_brokerServicePortTls", "6651")
+                    .withEnv("PULSAR_PREFIX_webServicePortTls", "8443")
+                    .withEnv("PULSAR_PREFIX_tlsTrustCertsFilePath", "/pulsar/certs/ca.cert.pem")
+                    .withEnv("PULSAR_PREFIX_tlsKeyFilePath", "/pulsar/certs/broker.key-pk8.pem")
+                    .withEnv("PULSAR_PREFIX_tlsCertificateFilePath", "/pulsar/certs/broker.cert.pem")
+                    .withEnv("PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect", "false")
+                    .withEnv("PULSAR_PREFIX_tlsEnableHostnameVerification", "false")
+                    .withEnv("PULSAR_PREFIX_tlsTrustStore", "NONE")
+                    .start()
         } catch (Exception e) {
             throw new Exception(PULSAR_CONTAINER.getLogs(OutputFrame.OutputType.STDERR), e)
         }


### PR DESCRIPTION
Pulsar client library doesn't use skip verify hostname property anymore or at least it won't set it on trust manager. Maybe default one used (from Java) changed in newer versions so that it forces hostname verification. Either way have to allow insecure to make tests work. For "production" usage it should not be used anyway and if it's required for some reason allow insecure has to be used or custom trust store which can be set on pulsar anyway through properties