### PR TITLE
Start 3.2.x at 3.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.pulsar-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.pulsar-module.gradle
@@ -10,6 +10,9 @@ dependencies {
         api(libs.managed.jackson.databind) {
             because 'Apache Pulsar 4.2.3 brings Jackson Databind 2.18.8, which is vulnerable to GHSA-5jmj-h7xm-6q6v'
         }
+        api(libs.async.http.client) {
+            because 'Apache Pulsar 4.2.4 brings AsyncHttpClient 2.15.0, which is vulnerable to GHSA-m452-q8c9-rg2f'
+        }
     }
     testRuntimeOnly mnLogging.logback.classic
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.1.1-SNAPSHOT
+projectVersion=3.2.0-SNAPSHOT
 projectGroup=io.micronaut.pulsar
 title=Micronaut Pulsar
 projectDesc=Integration between Micronaut and Apache Pulsar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+async-http-client = '2.16.1'
 conscrypt-openjdk = '2.6.1'
 micronaut = "5.2.0"
 micronaut-platform = '5.1.4'
@@ -29,6 +30,7 @@ managed-pulsar-client = { module = 'org.apache.pulsar:pulsar-client-original', v
 managed-jackson-databind = { module = 'com.fasterxml.jackson.core:jackson-databind', version.ref = 'managed-jackson-databind' }
 
 # Other libraries
+async-http-client = { module = 'org.asynchttpclient:async-http-client', version.ref = 'async-http-client' }
 conscrypt-openjdk = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref="conscrypt-openjdk" }
 testcontainers-pulsar = { module = 'org.testcontainers:testcontainers-pulsar' }
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = 'micronaut-gradle-plugin' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 conscrypt-openjdk = '2.6.1'
-micronaut = "5.1.6"
-micronaut-platform = '5.0.5'
+micronaut = "5.2.0"
+micronaut-platform = '5.1.4'
 micronaut-gradle-plugin = '5.0.2'
 micronaut-grpc = "5.1.0"
 micronaut-multitenancy = "6.1.0"
 micronaut-validation = "5.1.0"
-micronaut-reactor = "4.1.0"
-micronaut-serde = "3.1.0"
-micronaut-test-resources = "4.0.0"
+micronaut-reactor = "4.2.0"
+micronaut-serde = "3.1.1"
+micronaut-test-resources = "4.2.0"
 managed-pulsar-client = '4.2.4'
 managed-jackson-databind = '2.22.1'
 


### PR DESCRIPTION
Starts the new minor branch `3.2.x` (created from `3.1.x`) at `3.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `3.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

The `gradle/libs.versions.toml` changes of the Renovate PR #854 on `3.1.x` are reused here.
Switching the default and Renovate base branch to `3.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)