### PR TITLE
Fix audit on 3.1.x: constrain async-http-client to 2.16.1, update Core to 5.1.14

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.pulsar-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.pulsar-module.gradle
@@ -10,6 +10,9 @@ dependencies {
         api(libs.managed.jackson.databind) {
             because 'Apache Pulsar 4.2.3 brings Jackson Databind 2.18.8, which is vulnerable to GHSA-5jmj-h7xm-6q6v'
         }
+        api(libs.async.http.client) {
+            because 'Apache Pulsar 4.2.4 brings AsyncHttpClient 2.15.0, which is vulnerable to GHSA-m452-q8c9-rg2f'
+        }
     }
     testRuntimeOnly mnLogging.logback.classic
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+async-http-client = '2.16.1'
 conscrypt-openjdk = '2.6.1'
 micronaut = "5.1.6"
 micronaut-platform = '5.0.5'
@@ -29,6 +30,7 @@ managed-pulsar-client = { module = 'org.apache.pulsar:pulsar-client-original', v
 managed-jackson-databind = { module = 'com.fasterxml.jackson.core:jackson-databind', version.ref = 'managed-jackson-databind' }
 
 # Other libraries
+async-http-client = { module = 'org.asynchttpclient:async-http-client', version.ref = 'async-http-client' }
 conscrypt-openjdk = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref="conscrypt-openjdk" }
 testcontainers-pulsar = { module = 'org.testcontainers:testcontainers-pulsar' }
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = 'micronaut-gradle-plugin' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 async-http-client = '2.16.1'
 conscrypt-openjdk = '2.6.1'
-micronaut = "5.1.6"
+micronaut = "5.1.14"
 micronaut-platform = '5.0.5'
 micronaut-gradle-plugin = '5.0.2'
 micronaut-grpc = "5.1.0"


### PR DESCRIPTION
Fixes the `audit (25)` check on 3.1.x.

`pulsar-client-original` 4.2.4, the latest Apache Pulsar release, brings findings that fail the vulnerability audit. There is no newer Pulsar client to upgrade to.

- **async-http-client 2.15.0** (GHSA-m452-q8c9-rg2f): add an `api` constraint to 2.16.1, the version Pulsar's branch-4.2 uses. This is a cherry-pick of d1be617 from `claude/core-5.2-bump-3.2.x` (#855). The constraint can be removed once a Pulsar release ships async-http-client >= 2.16.0.
- **netty-codec-http / netty-handler 4.2.16.Final** (GHSA-8c42-7qj2-3j46, GHSA-c4c3-7fpv-j4q5, GHSA-fccg-mwvh-qqg4): update Micronaut Core from 5.1.6 to 5.1.14, whose BOM manages Netty 4.2.17.Final.

Verified locally:
- `.github/scripts/vulnerability-audit.sh` reports "No known vulnerabilities found." It still prints the existing unused ignore GHSA-rcgg-9c38-7xpx, which is left in place.
- `./gradlew check` passes, including the 21 Testcontainers tests in `test-suite:*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
